### PR TITLE
Fix: reset_pk_sequence arguments 

### DIFF
--- a/lib/tasks/csv_load.rake
+++ b/lib/tasks/csv_load.rake
@@ -72,7 +72,7 @@ desc "customers"
       t.save
     end
     puts "Items loaded"
-    ActiveRecord::Base.connection.reset_pk_sequence!('invoices')
+    ActiveRecord::Base.connection.reset_pk_sequence!('items')
   end
   
   task merchants: :environment do
@@ -88,7 +88,7 @@ desc "customers"
       t.save
     end
     puts "Merchants loaded"
-    ActiveRecord::Base.connection.reset_pk_sequence!('invoices')
+    ActiveRecord::Base.connection.reset_pk_sequence!('merchants')
   end
   
   task transactions: :environment do
@@ -107,7 +107,7 @@ desc "customers"
       t.save
     end
     puts "Transactions loaded"
-    ActiveRecord::Base.connection.reset_pk_sequence!('invoices')
+    ActiveRecord::Base.connection.reset_pk_sequence!('transactions')
   end
 
   task all: :environment do
@@ -120,6 +120,4 @@ desc "customers"
     Rake::Task["csv_load:transactions"].invoke
     puts "all loaded"
   end
-
-
 end


### PR DESCRIPTION
Found a bug in our rake file whereby the argument passed to reset the primary key sequence for items, transactions, and merchants was 'invoices', rather than the appropriate table name for which the primary key needed to be reset. 