### PR TITLE
22 admin dashboard incomplete invoices

### DIFF
--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,5 +1,6 @@
 class Admin::DashboardsController < ApplicationController
   def dashboard
     @customers = Customer.all
+    @invoices = Invoice.all
   end
 end

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -1,4 +1,8 @@
 class Admin::InvoicesController < ApplicationController
   def index
   end
+
+  def show
+    @invoice = Invoice.find(params[:id])
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -5,4 +5,8 @@ class Invoice < ApplicationRecord
   has_many :transactions
   
   enum status: { "in progress": 0, completed: 1, cancelled: 2}
+
+  def self.incomplete_orders
+    joins(:invoice_items).select(:id).where(invoice_items: {status: [1, 0]}).uniq
+  end
 end

--- a/app/views/admin/dashboards/dashboard.html.erb
+++ b/app/views/admin/dashboards/dashboard.html.erb
@@ -10,3 +10,10 @@
     Transactions made: <%= customer.transaction_counter %>
   </p>
 <% end %>
+
+<section id = "Incomplete_Invoices">
+  <h2> Incomplete Invoices </h2>
+  <% @invoices.incomplete_orders.each do |invoice| %>
+    <%= link_to "ID: #{invoice.id}", "/admin/invoices/#{invoice.id}" %><br>
+  <% end %>
+</section>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,0 +1,5 @@
+<p>
+  ID: <%= @invoice.id %><br>
+  Customer ID: <%= @invoice.customer_id %><br>
+  Status: <%= @invoice.status %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get "/admin", to: "admin/dashboards#dashboard" 
   get "/admin/merchants", to: "admin/merchants#index"
   get "/admin/invoices", to: "admin/invoices#index"
+  get "/admin/invoices/:id", to: "admin/invoices#show"
 
   get "/merchants/:id/dashboard", to: "merchants#show"
   get "/merchants/:id/items", to: "merchants/items#index"

--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :customer do
-    first_name {Faker::Name.unique.first_name}
-    last_name {Faker::Name.unique.last_name}
+    first_name {Faker::Name.first_name}
+    last_name {Faker::Name.last_name}
   end
 end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -1,36 +1,21 @@
 require "rails_helper"
 
 RSpec.describe "Admin Dashboard" do
-  describe "When I visit the admin dashboard (/admin)" do
-    it "displays the admin dashboard" do
-      visit "/admin"
-      expect(page).to have_content("Admin Dashboard")
-    end
-
-    it "can display links" do
-      visit "/admin"
-      expect(page).to have_link("admin merchants")
-      expect(page).to have_link("admin invoices")
-
-      click_link "admin merchants"
-      expect(current_path).to eq("/admin/merchants")
-      
-      visit "/admin"
-      click_link "admin invoices"
-      expect(current_path).to eq("/admin/invoices")
-    end
-
-    it "displays the names of the top 5 customers, their name, and the number of successful transactions they have conducted" do
-      visit "/admin"
-      invoices = create_list(:invoice, 450)
-    end
-
-    let!(:person1) {Customer.create!( first_name: "Danger", last_name: "Powers")}
+  let!(:person1) {Customer.create!( first_name: "Danger", last_name: "Powers")}
     let!(:person2) {Customer.create!( first_name: "Forest", last_name: "Gump")}
     let!(:person3) {Customer.create!( first_name: "Sterling", last_name: "Archer")}
     let!(:person4) {Customer.create!( first_name: "Napoleon", last_name: "Dynamite")}
     let!(:person5) {Customer.create!( first_name: "Tom", last_name: "Hanks")}
     let!(:person6) {Customer.create!( first_name: "Ace", last_name: "Ventura")}
+
+    let!(:merchant1) {Merchant.create!(name: 'Merchant 1')}
+
+    let!(:item1) {Item.create!(name: "Toy", description: "Toy", unit_price: 100, merchant_id: merchant1.id )}
+    let!(:item2) {Item.create!(name: "Food", description:  "Food", unit_price: 600, merchant_id: merchant1.id)}
+    let!(:item3) {Item.create!(name: "Shoes", description: "Shoes", unit_price: 12000, merchant_id: merchant1.id)}
+    let!(:item4) {Item.create!(name: "boat", description: "boat", unit_price: 5000000, merchant_id: merchant1.id)}
+    let!(:item5) {Item.create!(name: "cards", description: "cards", unit_price: 500, merchant_id: merchant1.id)}
+    let!(:item6) {Item.create!(name: "sponge", description: "sponge", unit_price: 200, merchant_id: merchant1.id)}
     
     let!(:invoice1) {Invoice.create!( customer_id: person1.id, status: 1)}
     let!(:invoice2) {Invoice.create!( customer_id: person1.id, status: 1)}
@@ -65,8 +50,40 @@ RSpec.describe "Admin Dashboard" do
     let!(:transaction14) {Transaction.create!( invoice_id: invoice14.id, result: 0)}
     let!(:transaction15) {Transaction.create!( invoice_id: invoice15.id, result: 0)}
     let!(:transaction16) {Transaction.create!( invoice_id: invoice16.id, result: 1)}
+   
+    let!(:invoice_item1) {InvoiceItem.create!( item_id: item1.id, invoice_id: invoice1.id, status: 0)}
+    let!(:invoice_item2) {InvoiceItem.create!( item_id: item2.id, invoice_id: invoice1.id, status: 1)}
+    let!(:invoice_item3) {InvoiceItem.create!( item_id: item3.id, invoice_id: invoice2.id, status: 0)}
+    let!(:invoice_item4) {InvoiceItem.create!( item_id: item4.id, invoice_id: invoice2.id, status: 1)}
+    let!(:invoice_item5) {InvoiceItem.create!( item_id: item5.id, invoice_id: invoice3.id, status: 0)}
+    let!(:invoice_item7) {InvoiceItem.create!( item_id: item6.id, invoice_id: invoice4.id, status: 2)}
 
 
+
+  describe "When I visit the admin dashboard (/admin)" do
+    it "displays the admin dashboard" do
+      visit "/admin"
+      expect(page).to have_content("Admin Dashboard")
+    end
+
+    it "can display links" do
+      visit "/admin"
+      expect(page).to have_link("admin merchants")
+      expect(page).to have_link("admin invoices")
+
+      click_link "admin merchants"
+      expect(current_path).to eq("/admin/merchants")
+      
+      visit "/admin"
+      click_link "admin invoices"
+      expect(current_path).to eq("/admin/invoices")
+    end
+
+    it "displays the names of the top 5 customers, their name, and the number of successful transactions they have conducted" do
+      visit "/admin"
+      invoices = create_list(:invoice, 450)
+    end
+    
     it "#top_5_customers" do
       visit "/admin"
       expect(page).to have_content(person1.first_name)
@@ -94,11 +111,11 @@ RSpec.describe "Admin Dashboard" do
 
       visit "/admin"
       within("#Incomplete_Invoices") do
-        invoices = create_list(:invoice, 5)
-        invoice_items = create_list(:invoice_item, 5)
-        require 'pry'; binding.pry
-          expect(page).to have_content("Incomplete Invoices")
-          expect(page).to have_content()
+        expect(page).to have_content("Incomplete Invoices")
+        expect(page).to have_content(invoice1.id)
+        expect(page).to have_content(invoice2.id)
+        expect(page).to have_content(invoice3.id)
+        expect(page).to_not have_content(invoice4.id)
       end
     end
   end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -83,6 +83,24 @@ RSpec.describe "Admin Dashboard" do
       expect("Forest, Gump").to appear_before("Sterling, Archer", only_text: true)
       expect("Sterling, Archer").to_not appear_before("Danger, Powers", only_text: true)
     end
+
+    # As an admin,
+    # When I visit the admin dashboard (/admin)
+    # Then I see a section for "Incomplete Invoices"
+    # In that section I see a list of the ids of all invoices
+    # That have items that have not yet been shipped
+    # And each invoice id links to that invoice's admin show page
+    it "displays incomomplete invoices" do
+
+      visit "/admin"
+      within("#Incomplete_Invoices") do
+        invoices = create_list(:invoice, 5)
+        invoice_items = create_list(:invoice_item, 5)
+        require 'pry'; binding.pry
+          expect(page).to have_content("Incomplete Invoices")
+          expect(page).to have_content()
+      end
+    end
   end
 end
 

--- a/spec/features/merchant/show_spec.rb
+++ b/spec/features/merchant/show_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe 'Merchant Dashboard' do
     describe "US3 Lists Top 5 Customers" do
       it "I see the names of the top 5 customers who have conducted the largest number of successful transactions with my merchant " do
         visit "/merchants/#{@merchant_1.id}/dashboard"
-save_and_open_page
 
         within(".top_five_customers")do
           expect(page).to have_content("Top Five Customers")

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -9,13 +9,68 @@ RSpec.describe Invoice, type: :model do
     
     it { should define_enum_for(:status).with_values("in progress": 0, completed: 1, cancelled: 2)}
   end
+  let!(:person1) {Customer.create!( first_name: "Danger", last_name: "Powers")}
+    let!(:person2) {Customer.create!( first_name: "Forest", last_name: "Gump")}
+    let!(:person3) {Customer.create!( first_name: "Sterling", last_name: "Archer")}
+    let!(:person4) {Customer.create!( first_name: "Napoleon", last_name: "Dynamite")}
+    let!(:person5) {Customer.create!( first_name: "Tom", last_name: "Hanks")}
+    let!(:person6) {Customer.create!( first_name: "Ace", last_name: "Ventura")}
+
+    let!(:merchant1) {Merchant.create!(name: 'Merchant 1')}
+
+    let!(:item1) {Item.create!(name: "Toy", description: "Toy", unit_price: 100, merchant_id: merchant1.id )}
+    let!(:item2) {Item.create!(name: "Food", description:  "Food", unit_price: 600, merchant_id: merchant1.id)}
+    let!(:item3) {Item.create!(name: "Shoes", description: "Shoes", unit_price: 12000, merchant_id: merchant1.id)}
+    let!(:item4) {Item.create!(name: "boat", description: "boat", unit_price: 5000000, merchant_id: merchant1.id)}
+    let!(:item5) {Item.create!(name: "cards", description: "cards", unit_price: 500, merchant_id: merchant1.id)}
+    let!(:item6) {Item.create!(name: "sponge", description: "sponge", unit_price: 200, merchant_id: merchant1.id)}
+    
+    let!(:invoice1) {Invoice.create!( customer_id: person1.id, status: 1)}
+    let!(:invoice2) {Invoice.create!( customer_id: person1.id, status: 1)}
+    let!(:invoice3) {Invoice.create!( customer_id: person1.id, status: 1)}
+    let!(:invoice4) {Invoice.create!( customer_id: person1.id, status: 1)}
+    let!(:invoice5) {Invoice.create!( customer_id: person1.id, status: 1)}
+    let!(:invoice6) {Invoice.create!( customer_id: person2.id, status: 1)}
+    let!(:invoice7) {Invoice.create!( customer_id: person2.id, status: 1)}
+    let!(:invoice8) {Invoice.create!( customer_id: person2.id, status: 1)}
+    let!(:invoice9) {Invoice.create!( customer_id: person2.id, status: 1)}
+    let!(:invoice10) {Invoice.create!( customer_id: person3.id, status: 1)}
+    let!(:invoice11) {Invoice.create!( customer_id: person3.id, status: 1)}
+    let!(:invoice12) {Invoice.create!( customer_id: person3.id, status: 1)}
+    let!(:invoice13) {Invoice.create!( customer_id: person4.id, status: 1)}
+    let!(:invoice14) {Invoice.create!( customer_id: person4.id, status: 1)}
+    let!(:invoice15) {Invoice.create!( customer_id: person5.id, status: 1)}
+    let!(:invoice16) {Invoice.create!( customer_id: person6.id, status: 0)}
+
+    let!(:transaction1) {Transaction.create!( invoice_id: invoice1.id, result: 0)}
+    let!(:transaction2) {Transaction.create!( invoice_id: invoice2.id, result: 0)}
+    let!(:transaction3) {Transaction.create!( invoice_id: invoice3.id, result: 0)}
+    let!(:transaction4) {Transaction.create!( invoice_id: invoice4.id, result: 0)}
+    let!(:transaction5) {Transaction.create!( invoice_id: invoice5.id, result: 0)}
+    let!(:transaction6) {Transaction.create!( invoice_id: invoice6.id, result: 0)}
+    let!(:transaction7) {Transaction.create!( invoice_id: invoice7.id, result: 0)}
+    let!(:transaction8) {Transaction.create!( invoice_id: invoice8.id, result: 0)}
+    let!(:transaction9) {Transaction.create!( invoice_id: invoice9.id, result: 0)}
+    let!(:transaction10) {Transaction.create!( invoice_id: invoice10.id, result: 0)}
+    let!(:transaction11) {Transaction.create!( invoice_id: invoice11.id, result: 0)}
+    let!(:transaction12) {Transaction.create!( invoice_id: invoice12.id, result: 0)}
+    let!(:transaction13) {Transaction.create!( invoice_id: invoice13.id, result: 0)}
+    let!(:transaction14) {Transaction.create!( invoice_id: invoice14.id, result: 0)}
+    let!(:transaction15) {Transaction.create!( invoice_id: invoice15.id, result: 0)}
+    let!(:transaction16) {Transaction.create!( invoice_id: invoice16.id, result: 1)}
+   
+    let!(:invoice_item1) {InvoiceItem.create!( item_id: item1.id, invoice_id: invoice1.id, status: 0)}
+    let!(:invoice_item2) {InvoiceItem.create!( item_id: item2.id, invoice_id: invoice1.id, status: 1)}
+    let!(:invoice_item3) {InvoiceItem.create!( item_id: item3.id, invoice_id: invoice2.id, status: 0)}
+    let!(:invoice_item4) {InvoiceItem.create!( item_id: item4.id, invoice_id: invoice2.id, status: 1)}
+    let!(:invoice_item5) {InvoiceItem.create!( item_id: item5.id, invoice_id: invoice3.id, status: 0)}
+    let!(:invoice_item7) {InvoiceItem.create!( item_id: item6.id, invoice_id: invoice4.id, status: 2)}
+
+    describe "class methods" do
+      it "#incomplete_orders" do
+        expect(Invoice.incomplete_orders).to eq([invoice1, invoice2, invoice3])
+      end
+    end
+
 end
 
-# 21. Admin Dashboard Statistics - Top Customers
-
-# As an admin,
-# When I visit the admin dashboard (/admin)
-# Then I see the names of the top 5 customers
-# who have conducted the largest number of successful transactions
-# And next to each customer name I see the number of successful transactions they have
-# conducted


### PR DESCRIPTION
This adds an invoice show page, feature and model tests for incomplete orders on the admin show page. Each incomplete order links to the specific invoice show page.