### PR TITLE
feat admin merchant index ordered by enabled and disabled

### DIFF
--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,19 +1,48 @@
 <p>Merchants</p>
 
-<%= @merchants.each do |merchant| %>
-  <p>
-    Name: <%= link_to  "#{merchant.name}", "merchants/#{merchant.id}" %><br>
-    Status: <%= merchant.status %>
+<section id = "Disabled_merchants">
+  <p>Disabled Merchants</p>
+  <% @merchants.each do |merchant| %>
+    <% if merchant.status == "Disabled" %>
+      <p>
+        Name: <%= link_to  "#{merchant.name}", "merchants/#{merchant.id}" %><br>
+        Status: <%= merchant.status %>
 
-    # <%= form_with url: "/admin/merchants/#{merchant.id}", method: :patch, local: true do |f| %>
-      <%= hidden_field_tag :status, "Disabled" %>
-      <%= f.submit "Disable #{merchant.name}" %>
-    <% end %><br>
+        <%= form_with url: "/admin/merchants/#{merchant.id}", method: :patch, local: true do |f| %>
+          <%= hidden_field_tag :status, "Disabled" %>
+          <%= f.submit "Disable #{merchant.name}" %>
+        <% end %><br>
 
-    <%= form_with url: "/admin/merchants/#{merchant.id}", method: :patch, local: true do |f| %>
-      <%= hidden_field_tag :status, "Enabled" %>
-      <%= f.submit "Enable #{merchant.name}" %>
+        <%= form_with url: "/admin/merchants/#{merchant.id}", method: :patch, local: true do |f| %>
+          <%= hidden_field_tag :status, "Enabled" %>
+          <%= f.submit "Enable #{merchant.name}" %>
+        <% end %>
+      </p>
+
     <% end %>
+  <% end %>
+</section>
 
-  </p>
-<% end %>
+<section id = "Enabled_merchants">
+  <p>Enabled Merchants</p>
+
+  <% @merchants.each do |merchant| %>
+    <% if merchant.status == "Enabled" %>
+      <p>
+        Name: <%= link_to  "#{merchant.name}", "merchants/#{merchant.id}" %><br>
+        Status: <%= merchant.status %>
+
+        <%= form_with url: "/admin/merchants/#{merchant.id}", method: :patch, local: true do |f| %>
+          <%= hidden_field_tag :status, "Disabled" %>
+          <%= f.submit "Disable #{merchant.name}" %>
+        <% end %><br>
+
+        <%= form_with url: "/admin/merchants/#{merchant.id}", method: :patch, local: true do |f| %>
+          <%= hidden_field_tag :status, "Enabled" %>
+          <%= f.submit "Enable #{merchant.name}" %>
+        <% end %>
+      </p>
+    <% end %>
+  <% end %>
+</section>
+

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Admin Merchant" do
 
-  let!(:merchant1) {Merchant.create!(name: 'Stuff Emporium')}
-  let!(:merchant2) {Merchant.create!(name: 'Junk')}
-  let!(:merchant3) {Merchant.create!(name: 'Homemade stuff')}
-  let!(:merchant4) {Merchant.create!(name: 'Cool Stuff')}
+  let!(:merchant1) {Merchant.create!(name: 'Stuff Emporium', status: 0)}
+  let!(:merchant2) {Merchant.create!(name: 'Junk', status: 1)}
+  let!(:merchant3) {Merchant.create!(name: 'Homemade stuff', status: 0)}
+  let!(:merchant4) {Merchant.create!(name: 'Cool Stuff', status: 1)}
   
   it "displays merchant index page" do
     visit "/admin/merchants"
@@ -22,9 +22,27 @@ RSpec.describe "Admin Merchant" do
   end
   # As an admin,
   # When I visit the admin merchants index (/admin/merchants)
-  # Then next to each merchant name I see a button to disable or enable that merchant.
-  # When I click this button
-  # Then I am redirected back to the admin merchants index
-  # And I see that the merchant's status has changed
+  # Then I see two sections, one for "Enabled Merchants" and one for "Disabled Merchants"
+  # And I see that each Merchant is listed in the appropriate section
+  
+  it "sorts disabled merchants" do
+    visit "/admin/merchants"
+    within("#Disabled_merchants") do
+      expect(page).to have_content("Stuff Emporium")
+      expect(page).to have_content("Homemade stuff")
+      expect(page).to_not have_content("Cool Stuff")
+    end
+  end
+
+  it "sorts enabled merchants" do
+    visit "/admin/merchants"
+    within("#Enabled_merchants") do
+      expect(page).to have_content("Junk")
+      expect(page).to have_content("Cool Stuff")
+      expect(page).to_not have_content("Homemade stuff")
+    end
+  end
+    
+
 
 end


### PR DESCRIPTION
This adds sections to the admin merchants index that order the merchants by enabled or disabled